### PR TITLE
Implicits - fix 'implicitly' example with companion object

### DIFF
--- a/src/lectures/part4implicits/TypeClasses.scala
+++ b/src/lectures/part4implicits/TypeClasses.scala
@@ -108,7 +108,9 @@ object TypeClasses extends App {
 
   // implicitly
   case class Permissions(mask: String)
-  implicit val defaultPermissions: Permissions = Permissions("0744")
+  object Permissions {
+    implicit val defaultPermissions: Permissions = Permissions("0744")
+  }
 
   // in some other part of the  code
   val standardPerms = implicitly[Permissions]


### PR DESCRIPTION
Hello Daniel!
Currently the `implicitly[Permissions]` call will just return null when used from a different class.