### PR TITLE
Type Members - fix MList example

### DIFF
--- a/src/lectures/part5ts/TypeMembers.scala
+++ b/src/lectures/part5ts/TypeMembers.scala
@@ -58,16 +58,18 @@ object TypeMembers extends App {
     type A <: Number
   }
 
+  trait OurMList extends MList with ApplicableToNumbers
+
   // NOT OK
-//  class CustomList(hd: String, tl: CustomList) extends MList with ApplicableToNumbers {
+//  class CustomList(hd: String, tl: CustomList) extends OurMList {
 //    type A = String
 //    def head = hd
 //    def tail = tl
 //  }
 
   // OK
-  class IntList(hd: Int, tl: IntList) extends MList {
-    type A = Int
+  class IntList(hd: Integer, tl: IntList) extends OurMList {
+    type A = Integer
     def head = hd
     def tail = tl
   }


### PR DESCRIPTION
- introduce "internal" and so changeable trait extending MList
- use Java Integer in IntList to be compatible with Number bound

Fixes rockthejvm/scala-2-advanced#3