### PR TITLE
Type Members - complete IntList exercise

### DIFF
--- a/src/lectures/part5ts/TypeMembers.scala
+++ b/src/lectures/part5ts/TypeMembers.scala
@@ -66,8 +66,8 @@ object TypeMembers extends App {
 //  }
 
   // OK
-  class IntList(hd: Int, tl: IntList) extends MList {
-    type A = Int
+  class IntList(hd: Integer, tl: IntList) extends MList with ApplicableToNumbers {
+    type A = Integer
     def head = hd
     def tail = tl
   }


### PR DESCRIPTION
- add ApplicableToNumbers trait to IntList
- use Java Integer as inner type to be compatible with Number bound

Fixes rockthejvm/scala-2-advanced#3