### PR TITLE
doc - add note for Scala 2.12 version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains the code we wrote during  [Rock the JVM's Scala 2 Advan
 How to install:
 - either clone the repo or download as zip
 - open with IntelliJ as it's a simple IDEA project
+- ensure the project is configured to use Scala version 2.12
 
 If you have changes to suggest to this repo, either
 - submit a GitHub issue


### PR DESCRIPTION
- as ParallelUtils would be broken using Scala 2.13 where parallel collections are moved into a separate dependency